### PR TITLE
added crontabs and custom video bios (for gpu passthrough) files to backup.

### DIFF
--- a/prox_config_backup.sh
+++ b/prox_config_backup.sh
@@ -80,8 +80,8 @@ function are-we-root-abort-if-not {
 }
 
 function check-num-backups {
-    if [[ $(ls ${_bdir}/*${$_HOSTNAME}*.tar.gz -l | grep ^- | wc -l) -ge $MAX_BACKUPS ]]; then
-      local oldbackup="$(ls ${_bdir}/*${$_HOSTNAME}*.tar.gz -t | tail -1)"
+    if [[ $(ls ${_bdir}/*${_HOSTNAME}*.tar.gz -l | grep ^- | wc -l) -ge $MAX_BACKUPS ]]; then
+      local oldbackup="$(basename $(ls ${_bdir}/*${_HOSTNAME}*.tar.gz -t | tail -1))"
       echo "${_bdir}/${oldbackup}"
       rm "${_bdir}/${oldbackup}"
     fi

--- a/prox_config_backup.sh
+++ b/prox_config_backup.sh
@@ -80,8 +80,8 @@ function are-we-root-abort-if-not {
 }
 
 function check-num-backups {
-    if [[ $(ls ${_bdir}/*.tar.gz -l | grep ^- | wc -l) -ge $MAX_BACKUPS ]]; then
-      local oldbackup="$(ls ${_bdir}/*.tar.gz -t | tail -1)"
+    if [[ $(ls ${_bdir}/*${$_HOSTNAME}*.tar.gz -l | grep ^- | wc -l) -ge $MAX_BACKUPS ]]; then
+      local oldbackup="$(ls ${_bdir}/*${$_HOSTNAME}*.tar.gz -t | tail -1)"
       echo "${_bdir}/${oldbackup}"
       rm "${_bdir}/${oldbackup}"
     fi

--- a/prox_config_backup.sh
+++ b/prox_config_backup.sh
@@ -11,8 +11,8 @@ set -e
 
 # permanent backups directory
 # default value can be overridden by setting environment variable before running prox_config_backup.sh
-# example: export BACK_DIR="/mnt/pve/media/backup
-_bdir=${BACK_DIR:-/mnt/backups/proxmox}
+# example: export BACKUP_DIR="/mnt/pve/media/backup
+_bdir=${BACKUP_DIR:-/mnt/backups/proxmox}
 
 # number of backups to keep before overriding the oldest one
 MAX_BACKUPS=5
@@ -36,7 +36,9 @@ _HOSTNAME=$(hostname -f)
 _filename1="$_tdir/proxmoxetc.$_now.tar"
 _filename2="$_tdir/proxmoxpve.$_now.tar"
 _filename3="$_tdir/proxmoxroot.$_now.tar"
-_filename4="$_tdir/proxmox_backup_"$_HOSTNAME"_"$_now".tar.gz"
+_filename4="$_tdir/proxmoxcron.$_now.tar"
+_filename5="$_tdir/proxmoxvbios.$_now.tar"
+_filename_final="$_tdir/proxmox_backup_"$_HOSTNAME"_"$_now".tar.gz"
 
 ##########
 
@@ -49,7 +51,7 @@ function description {
         Timestamp: "$_now"
 
         Files to be saved:
-        "/etc/*, /var/lib/pve-cluster/*, /root/*"
+        "/etc/*, /var/lib/pve-cluster/*, /root/*, /var/spool/cron/*, /usr/share/kvm/*.vbios"
 
         Backup target:
         "$_bdir"
@@ -91,16 +93,21 @@ function copyfilesystem {
     tar --warning='no-file-ignored' -cvPf "$_filename1" /etc/.
     tar --warning='no-file-ignored' -cvPf "$_filename2" /var/lib/pve-cluster/.
     tar --warning='no-file-ignored' -cvPf "$_filename3" /root/.
+    tar --warning='no-file-ignored' -cvPf "$_filename4" /var/spool/cron/.
+    if [ "$(ls /usr/share/kvm/*.vbios 2>/dev/null)" != "" ] ; then
+	echo backing up custom video bios...
+	tar --warning='no-file-ignored' -cvPf "$_filename5" /usr/share/kvm/*.vbios
+    fi
 }
 
 function compressandarchive {
     echo "Compressing files"
     # archive the copied system files
-    tar -cvzPf "$_filename4" $_tdir/*.tar
+    tar -cvzPf "$_filename_final" $_tdir/*.tar
 
     # copy config archive to backup folder
     # this may be replaced by scp command to place in remote location
-    cp $_filename4 $_bdir/
+    cp $_filename_final $_bdir/
 }
 
 function stopservices {

--- a/prox_config_backup.sh
+++ b/prox_config_backup.sh
@@ -12,7 +12,7 @@ set -e
 # permanent backups directory
 # default value can be overridden by setting environment variable before running prox_config_backup.sh
 # example: export BACKUP_DIR="/mnt/pve/media/backup
-_bdir=${BACKUP_DIR:-/mnt/backups/proxmox}
+_bdir=${BACK_DIR:-/mnt/backups/proxmox}
 
 # number of backups to keep before overriding the oldest one
 MAX_BACKUPS=5
@@ -80,8 +80,8 @@ function are-we-root-abort-if-not {
 }
 
 function check-num-backups {
-    if [[ $(ls ${_bdir} -l | grep ^- | wc -l) -ge $MAX_BACKUPS ]]; then
-      local oldbackup="$(ls ${_bdir} -t | tail -1)"
+    if [[ $(ls ${_bdir}/*.tar.gz -l | grep ^- | wc -l) -ge $MAX_BACKUPS ]]; then
+      local oldbackup="$(ls ${_bdir}/*.tar.gz -t | tail -1)"
       echo "${_bdir}/${oldbackup}"
       rm "${_bdir}/${oldbackup}"
     fi


### PR DESCRIPTION
The backup script doesn't backup any cron jobs the server may have, so I added /var/spools/cron to the backup. 
Also, in case someone is doing gpu passthrough, it may require that the video bios for the gpu be placed in /usr/share/kvm so the vm can pick it up. So I added   /usr/share/kvm/*.vbios to the backup as well.