### PR TITLE
Check backup directory exists before starting

### DIFF
--- a/prox_config_backup.sh
+++ b/prox_config_backup.sh
@@ -29,11 +29,16 @@ HEALTHCHECKS_URL=https://hc-ping.com/your_uuid_here
 # Set terminal to "dumb" if not set (cron compatibility)
 export TERM=${TERM:-dumb}
 
+# always exit on error
+set -e
+
 # Set backup directory to default OR environment variable
 _bdir=${BACK_DIR:-$DEFAULT_BACK_DIR}
 
-# always exit on error
-set -e
+# Check backup directory exists
+if [[ ! -d "${_bdir}" ]] ; then
+    echo "Aborting because backup target does not exists" ; exit 1
+fi
 
 # temporary storage directory
 _tdir=${TMP_DIR:-/var/tmp}


### PR DESCRIPTION
Add a check that the given backup directory exists before starting the backup, instead of an error at the end of this script.

This is for me an useful feature to check if a specific subfolder on a mount is present (read: the remote storage is really mounted and not only the mountpoint).