### PR TITLE
Update prox_config_backup.sh

### DIFF
--- a/prox_config_backup.sh
+++ b/prox_config_backup.sh
@@ -125,9 +125,9 @@ function check-num-backups {
 function copyfilesystem {
     echo "Tar files"
     # copy key system files
-    tar --warning='no-file-ignored' -cvPf "$_filename1" /etc/.
+    tar --warning='no-file-ignored' -cvPf "$_filename1" --one-file-system /etc/.
     tar --warning='no-file-ignored' -cvPf "$_filename2" /var/lib/pve-cluster/.
-    tar --warning='no-file-ignored' -cvPf "$_filename3" /root/.
+    tar --warning='no-file-ignored' -cvPf "$_filename3" --one-file-system /root/.
     tar --warning='no-file-ignored' -cvPf "$_filename4" /var/spool/cron/.
 
     if [ "$(ls -A /usr/local/bin 2>/dev/null)" ]; then tar --warning='no-file-ignored' -cvPf "$_filename8" /usr/local/bin/.; fi


### PR DESCRIPTION
when using mount within f.ex. root path, the tar tries to backup all data within mount. and the tmp directory could explode.
adding --one-file-system parameter to some tar cmds