### PR TITLE
Also back up /etc/pve

### DIFF
--- a/prox_config_backup.sh
+++ b/prox_config_backup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# Version	      0.2.3
-# Date		      04.18.2022
+# Version	      0.2.4
+# Date		      08.04.2024
 # Author 	      DerDanilo 
-# Contributors        aboutte, xmirakulix, bootsie123, phidauex
+# Contributors    aboutte, xmirakulix, bootsie123, phidauex
 
 ###########################
 # Configuration Variables #
@@ -117,7 +117,7 @@ function are-we-root-abort-if-not {
 
 function check-num-backups {
     if [[ $(ls ${_bdir}/*${_HOSTNAME}*_*.tar.gz -l | grep ^- | wc -l) -ge $MAX_BACKUPS ]]; then
-      local oldbackup="$(basename $(ls ${_bdir}/*${_HOSTNAME}*_*.tar.gz -t | tail -1))"
+      local oldbackup="$(basename $(ls ${_bdir}/*${_HOSTNAME}*.tar.gz -t | tail -1))"
       echo "${_bdir}/${oldbackup}"
       rm "${_bdir}/${oldbackup}"
     fi

--- a/prox_config_backup.sh
+++ b/prox_config_backup.sh
@@ -64,14 +64,15 @@ trap clean_up EXIT
 _now=$(date +%Y-%m-%d.%H.%M.%S)
 _HOSTNAME=$(hostname -f)
 _filename1="$_tdir/proxmoxetc.$_now.tar"
-_filename2="$_tdir/proxmoxpve.$_now.tar"
+_filename2="$_tdir/proxmoxvarlibpve.$_now.tar"
 _filename3="$_tdir/proxmoxroot.$_now.tar"
 _filename4="$_tdir/proxmoxcron.$_now.tar"
 _filename5="$_tdir/proxmoxvbios.$_now.tar"
 _filename6="$_tdir/proxmoxpackages.$_now.list"
 _filename7="$_tdir/proxmoxreport.$_now.txt"
 _filename8="$_tdir/proxmoxlocalbin.$_now.tar"
-_filename_final="$_tdir/proxmox_backup_"$_HOSTNAME"_"$_now".tar.gz"
+_filename9="$_tdir/proxmoxetcpve.$_now.tar"
+_filename_final="$_tdir/proxmox_"$_now".tar.gz"
 
 ##########
 
@@ -115,8 +116,8 @@ function are-we-root-abort-if-not {
 }
 
 function check-num-backups {
-    if [[ $(ls ${_bdir}/*${_HOSTNAME}*.tar.gz -l | grep ^- | wc -l) -ge $MAX_BACKUPS ]]; then
-      local oldbackup="$(basename $(ls ${_bdir}/*${_HOSTNAME}*.tar.gz -t | tail -1))"
+    if [[ $(ls ${_bdir}/proxmox_*.tar.gz -l | grep ^- | wc -l) -ge $MAX_BACKUPS ]]; then
+      local oldbackup="$(basename $(ls ${_bdir}/proxmox_*.tar.gz -t | tail -1))"
       echo "${_bdir}/${oldbackup}"
       rm "${_bdir}/${oldbackup}"
     fi
@@ -126,6 +127,7 @@ function copyfilesystem {
     echo "Tar files"
     # copy key system files
     tar --warning='no-file-ignored' -cvPf "$_filename1" --one-file-system /etc/.
+    tar --warning='no-file-ignored' -cvPf "$_filename9" --one-file-system /etc/pve/.
     tar --warning='no-file-ignored' -cvPf "$_filename2" /var/lib/pve-cluster/.
     tar --warning='no-file-ignored' -cvPf "$_filename3" --one-file-system /root/.
     tar --warning='no-file-ignored' -cvPf "$_filename4" /var/spool/cron/.

--- a/prox_config_backup.sh
+++ b/prox_config_backup.sh
@@ -62,7 +62,7 @@ trap clean_up EXIT
 
 # Don't change if not required
 _now=$(date +%Y-%m-%d.%H.%M.%S)
-_HOSTNAME=$(hostname -f)
+_HOSTNAME=$(hostname)
 _filename1="$_tdir/proxmoxetc.$_now.tar"
 _filename2="$_tdir/proxmoxvarlibpve.$_now.tar"
 _filename3="$_tdir/proxmoxroot.$_now.tar"
@@ -72,7 +72,7 @@ _filename6="$_tdir/proxmoxpackages.$_now.list"
 _filename7="$_tdir/proxmoxreport.$_now.txt"
 _filename8="$_tdir/proxmoxlocalbin.$_now.tar"
 _filename9="$_tdir/proxmoxetcpve.$_now.tar"
-_filename_final="$_tdir/proxmox_"$_now".tar.gz"
+_filename_final="$_tdir/pve_"$_HOSTNAME"_"$_now".tar.gz"
 
 ##########
 
@@ -116,8 +116,8 @@ function are-we-root-abort-if-not {
 }
 
 function check-num-backups {
-    if [[ $(ls ${_bdir}/proxmox_*.tar.gz -l | grep ^- | wc -l) -ge $MAX_BACKUPS ]]; then
-      local oldbackup="$(basename $(ls ${_bdir}/proxmox_*.tar.gz -t | tail -1))"
+    if [[ $(ls ${_bdir}/*${_HOSTNAME}*_*.tar.gz -l | grep ^- | wc -l) -ge $MAX_BACKUPS ]]; then
+      local oldbackup="$(basename $(ls ${_bdir}/*${_HOSTNAME}*_*.tar.gz -t | tail -1))"
       echo "${_bdir}/${oldbackup}"
       rm "${_bdir}/${oldbackup}"
     fi

--- a/prox_config_restore.sh
+++ b/prox_config_restore.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
-# Version	      0.2.3
-# Date		      04.18.2022
+# Version	      0.2.4
+# Date		      08.04.2024
 # Author 	      razem-io 
 # Contributors
 
 # Very basic restore script based on https://github.com/DerDanilo/proxmox-stuff/issues/5
 
 # Restores backup from prox_config_backup.sh
-#   example: prox_config_restore.sh proxmox_backup_proxmoxhostname_2017-12-02.15.48.10.tar.gz
+#   example: prox_config_restore.sh pve_proxmoxhostname_2023-12-02.15.48.10.tar.gz
 
 set -e
 
 if [[ $# -eq 0 ]] ; then
-    echo 'Argument missing -> restore.sh proxmox_backup_proxmoxhostname_2017-12-02.15.48.10.tar.gz'
+    echo 'Argument missing -> restore.sh pve_proxmoxhostname_2023-12-02.15.48.10.tar.gz'
     exit 0
 fi
 


### PR DESCRIPTION
The script used to print this to stderr: `tar: /etc/./pve/: file is on a different filesystem; not dumped`
Now it still does but at least it creates a new tar just for that folder, which I believe is useful.
I also confirmed that that it used to actually not save that folder by opening a completed backup, now it does.