### PR TITLE
Add option to backup /opt folder

### DIFF
--- a/prox_config_backup.sh
+++ b/prox_config_backup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Version	      0.2.4
-# Date		      08.04.2024
+# Version	      0.3.0
+# Date		      19.04.2024
 # Author 	      DerDanilo 
 # Contributors    aboutte, xmirakulix, bootsie123, phidauex
 
@@ -17,6 +17,9 @@ DEFAULT_BACK_DIR="/mnt/pve/media/backup"
 
 # number of backups to keep before overriding the oldest one
 MAX_BACKUPS=5
+
+# Set to 'true' to backup /opt/* folder
+BACKUP_OPT_FOLDER=false
 
 # Healthchecks.io notification service
 # Set to 1 to use Healthchecks.io
@@ -72,6 +75,7 @@ _filename6="$_tdir/proxmoxpackages.$_now.list"
 _filename7="$_tdir/proxmoxreport.$_now.txt"
 _filename8="$_tdir/proxmoxlocalbin.$_now.tar"
 _filename9="$_tdir/proxmoxetcpve.$_now.tar"
+_filename10="$_tdir/proxmoxopt.$_now.tar"
 _filename_final="$_tdir/pve_"$_HOSTNAME"_"$_now".tar.gz"
 
 ##########
@@ -80,6 +84,8 @@ function description {
 # Check to see if we are in an interactive terminal, if not, skip the description
     if [[ -t 0 && -t 1 ]]; then
         clear
+        files_to_be_saved="/etc/*, /var/lib/pve-cluster/*, /root/*, /var/spool/cron/*, /usr/share/kvm/*.vbios"
+        if [ "$BACKUP_OPT_FOLDER" = true ]; then files_to_be_saved="${files_to_be_saved}, /opt/*"; fi
         cat <<EOF
 
         Proxmox Server Config Backup
@@ -87,7 +93,7 @@ function description {
         Timestamp: "$_now"
 
         Files to be saved:
-        "/etc/*, /var/lib/pve-cluster/*, /root/*, /var/spool/cron/*, /usr/share/kvm/*.vbios"
+        "$files_to_be_saved"
 
         Backup target:
         "$_bdir"
@@ -131,6 +137,8 @@ function copyfilesystem {
     tar --warning='no-file-ignored' -cvPf "$_filename2" /var/lib/pve-cluster/.
     tar --warning='no-file-ignored' -cvPf "$_filename3" --one-file-system /root/.
     tar --warning='no-file-ignored' -cvPf "$_filename4" /var/spool/cron/.
+
+    if [ "$BACKUP_OPT_FOLDER" = true ]; then tar --warning='no-file-ignored' -cvPf "$_filename10" --one-file-system /opt/.; fi
 
     if [ "$(ls -A /usr/local/bin 2>/dev/null)" ]; then tar --warning='no-file-ignored' -cvPf "$_filename8" /usr/local/bin/.; fi
 


### PR DESCRIPTION
Hi!
Thanks for the script. 

I added a disabled option to allow saving the /opt directory as well, because often some related files for server management can be put there.

Checked it on my system, it worked correctly, but if something is wrong I can fix it. 

### And a note about ansible. 
I didn't add a similar option for ansible because I can't test it for correct operation, but I think someone else can implement it quickly enough if needed.