### PR TITLE
fix hostname anchoring, improve backup expiration behavior

### DIFF
--- a/prox_config_backup.sh
+++ b/prox_config_backup.sh
@@ -116,10 +116,10 @@ function are-we-root-abort-if-not {
 }
 
 function check-num-backups {
-    if [[ $(ls ${_bdir}/*${_HOSTNAME}*_*.tar.gz -l | grep ^- | wc -l) -ge $MAX_BACKUPS ]]; then
-      local oldbackup="$(basename $(ls ${_bdir}/*${_HOSTNAME}*.tar.gz -t | tail -1))"
-      echo "${_bdir}/${oldbackup}"
-      rm "${_bdir}/${oldbackup}"
+    if [[ $(ls ${_bdir}/*_${_HOSTNAME}_*.tar.gz | wc -l) -ge $MAX_BACKUPS ]]; then
+      local oldbackups="$(ls ${_bdir}/*_${_HOSTNAME}_*.tar.gz -t | tail -n +$MAX_BACKUPS)"
+      echo "${oldbackups}"
+      rm ${oldbackups}
     fi
 }
 


### PR DESCRIPTION
Hostname check was not anchored, hostnames like pve and pve2 could result in a backup on pve2 clobbering host pve backups.

Improved backup expiry strategy, was limited to expiring at most one old backup. This would not be the expected behavior if user changed MAX_BACKUPS from 5 to 3, there would still always have been 5 hanging around.

Future, consider using hostname -f to further improve uniqueness, and 2>/dev/null for the if..ls to avoid a first run error to stdout (when no previous backups exist).