### PR TITLE
Issue #33: Add restore script tweak to comment out /etc/fstab during config restore process

### DIFF
--- a/prox_config_restore.sh
+++ b/prox_config_restore.sh
@@ -16,6 +16,32 @@ if [[ $# -eq 0 ]] ; then
     exit 0
 fi
 
+echo "Select restore mode:"
+echo "1) Default restore"
+echo "2) Restore with /etc/fstab commented out and saved as /etc/fstab_RESTORED"
+read -p "Enter choice (1 or 2): " CHOICE
+
+case "$CHOICE" in
+    1)
+        COMMENT_FSTAB=false
+        ;;
+    2)
+        COMMENT_FSTAB=true
+        echo "WARNING: Option 2 is experimental and may be suitable for new Proxmox systems."
+        echo "A copy of the /etc/fstab file from your backup will be made, all lines will be commented out, and the copy and saved as /etc/fstab_RESTORED and moved to /etc."
+        echo "It is your responsibility to make any necessary configuration updates to /etc/fstab based on /etc/fstab_RESTORED."
+        read -p "Are you sure you want to proceed with this option? (y/n): " CONFIRMATION
+        if [[ "$CONFIRMATION" != "y" && "$CONFIRMATION" != "Y" ]]; then
+            echo "Option aborted. Exiting."
+            exit 1
+        fi
+        ;;
+    *)
+        echo "Invalid choice. Exiting."
+        exit 1
+        ;;
+esac
+
 FOLDER_1="./$1_1"
 FOLDER_2="./$1_2"
 
@@ -25,11 +51,28 @@ mkdir "$FOLDER_2"
 tar -zxvf $1 -C "$FOLDER_1"
 find "$FOLDER_1" -name "*tar" -exec tar xvf '{}' -C "$FOLDER_2" \;
 
+if [ "$COMMENT_FSTAB" = true ]; then
+    echo "Processing /etc/fstab"
+    if [[ -f "$FOLDER_2/etc/fstab" ]]; then
+        sed 's/^/# /' "$FOLDER_2/etc/fstab" > /tmp/fstab_RESTORED
+    fi
+fi
+
 for i in pve-cluster pvedaemon vz qemu-server; do systemctl stop $i ; done || true
 
-cp -avr $FOLDER_2/. /
+if [ "$COMMENT_FSTAB" = true ] && [[ -f /tmp/fstab_RESTORED ]]; then
+    mv /tmp/fstab_RESTORED /etc/fstab_RESTORED
+else
+    find "$FOLDER_2" -type f ! -name 'fstab_RESTORED' -exec cp -a '{}' / \;
+fi
+
+cp -avr "$FOLDER_2/" /
 
 rm -r "$FOLDER_1" "$FOLDER_2" || true
+
+if [ "$COMMENT_FSTAB" = true ] && [[ -f /tmp/fstab_RESTORED ]]; then
+    rm /tmp/fstab_RESTORED
+fi
 
 read -p "Restore complete. Hit 'Enter' to reboot or CTRL+C to cancel."
 reboot


### PR DESCRIPTION
Hello,

I took a (f)stab at the tweaks suggested in Issue #33. Please let me know if there are any issues.

### Issue ticket number and link
Issue #33 

### Changes
update [https://github.com/party-at-ten-forward/proxmox-stuff/blob/master/prox_config_restore.sh](prox_config_restore.sh) per suggestions in Issue 33. 
- adding option for restoring /etc/fstab using suggested behavior of commenting out lines
- adding warning message and confirmation check as requested in issue thread [here](https://github.com/DerDanilo/proxmox-stuff/issues/33#issuecomment-2043327498)
- adding logic for creating temp copy from `/etc/fstab` in backup archive,
commenting out lines, and then moving to /etc without overwriting existing /etc/fstab. Temp copy is called `fstab_RESTORED`

### Testing Environment
- Hardware: macOS 13.6.7 Ventura, M1 Mac
- Virtualization Platform: UTM v5.4.3
- Proxmox VE version: Proxmox VE 8.2.1 
- Project Release: project as of commit 2bfca04

Thanks!